### PR TITLE
Added tests for set persona feature

### DIFF
--- a/test/NeptuneMutualNft/SetPersona.sol
+++ b/test/NeptuneMutualNft/SetPersona.sol
@@ -1,0 +1,41 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "../base/Spec.sol";
+
+contract SetPersona is Spec {
+  function testSetPersonaInvalid(uint8 persona) external {
+    vm.assume(persona != 1 && persona != 2);
+
+    address sender = address(3);
+
+    NeptuneMutualNft nft = new NeptuneMutualNft(sender, sender, "https://neptunemutual.com/");
+
+    vm.expectRevert("Error: invalid persona");
+    nft.setPersona(persona);
+  }
+
+  function testSetPersona(uint8 persona) external {
+    vm.assume(persona == 1 || persona == 2);
+
+    address sender = address(1);
+
+    NeptuneMutualNft nft = new NeptuneMutualNft(sender, sender, "https://neptunemutual.com/");
+
+    nft.setPersona(persona);
+  }
+
+  function testSetPersonaTwice(uint8 persona) external {
+    vm.assume(persona == 1 || persona == 2);
+
+    address sender = address(1);
+
+    NeptuneMutualNft nft = new NeptuneMutualNft(sender, sender, "https://neptunemutual.com/");
+
+    nft.setPersona(persona);
+
+    vm.expectRevert("Error: already set");
+    nft.setPersona(persona);
+  }
+}


### PR DESCRIPTION
Added tests for `setPersona` to test following cases
- Transaction reverts when persona is not equal to `1` or `2`
- Transaction reverts when user tries to set persona twice
- Successfully sets persona of any user once